### PR TITLE
reset() in env returns an obs to conform with Gym spec. Fixes #6

### DIFF
--- a/gym_duckietown_agent/envs/simplesimagent_env.py
+++ b/gym_duckietown_agent/envs/simplesimagent_env.py
@@ -63,7 +63,7 @@ class SimpleSimAgentEnv(gym.Env):
 
         # Initialize the state
         self.seed()
-        self.reset()  # FIXME: I'm quite sure this has to be called by the agent by gym convention
+        #self.reset()  # FIXME: I'm quite sure this has to be called by the agent by gym convention
 
     def reset(self):
         """
@@ -71,7 +71,7 @@ class SimpleSimAgentEnv(gym.Env):
         This also randomizes many environment parameters (domain randomization)
         """
 
-        self.sim.reset()
+        return self.sim.reset()
 
     def close(self):
         """


### PR DESCRIPTION
This PR makes the `reset()` method in the [simplesimagent_env](gym_duckietown_agent/envs/simplesimagent_env.py) return an observation to conform with proper Gym env spec. 

 - Fixes #6. 
 - This fix is related to and depends on duckietown/duckietown-slimremote#6